### PR TITLE
Resolve String(describing: ) warnings in CustomStringConvertible conformance

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -903,7 +903,7 @@ void t_swift_generator::generate_swift_struct_implementation(ofstream& out,
 
   generate_swift_struct_equatable_extension(out, tstruct, is_private);
 
-  if (!is_private && !is_result && (gen_cocoa_ || debug_descriptions_)) {  // old compiler didn't use debug_descriptions, OR it with gen_cocoa_ so the flag doesn't matter w/ cocoa
+  if (!is_private && !is_result && (gen_cocoa_)) {  // old compiler didn't use debug_descriptions, OR it with gen_cocoa_ so the flag doesn't matter w/ cocoa
     generate_swift_struct_printable_extension(out, tstruct);
   }
 

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -903,7 +903,7 @@ void t_swift_generator::generate_swift_struct_implementation(ofstream& out,
 
   generate_swift_struct_equatable_extension(out, tstruct, is_private);
 
-  if (!is_private && !is_result && (gen_cocoa_)) {  // old compiler didn't use debug_descriptions, OR it with gen_cocoa_ so the flag doesn't matter w/ cocoa
+  if (!is_private && !is_result && !gen_cocoa_) {  // old compiler didn't use debug_descriptions, OR it with gen_cocoa_ so the flag doesn't matter w/ cocoa
     generate_swift_struct_printable_extension(out, tstruct);
   }
 

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -1429,7 +1429,7 @@ void t_swift_generator::generate_swift_struct_printable_extension(ofstream& out,
       out << "(\"" << endl;
       for (f_iter = fields.begin(); f_iter != fields.end();) {
         indent(out) << "desc += \"" << (*f_iter)->get_name()
-                    << "=\\(self." << maybe_escape_identifier((*f_iter)->get_name()) << ")";
+                    << "=\\(String(describing: self." << maybe_escape_identifier((*f_iter)->get_name()) << "))";
         if (++f_iter != fields.end()) {
           out << ", ";
         }


### PR DESCRIPTION
Implemented the `String(describing: _)` introduced in swift 3.1 to silence the warnings.