### PR TITLE
Added secure option to TSocketTransport

### DIFF
--- a/lib/swift/Sources/TSocketTransport.swift
+++ b/lib/swift/Sources/TSocketTransport.swift
@@ -64,7 +64,7 @@ extension Stream.PropertyKey {
 
 /// TCFSocketTransport, uses CFSockets and (NS)Stream's
 public class TCFSocketTransport: TStreamTransport {
-  public init?(hostname: String, port: Int) {
+    public init?(hostname: String, port: Int, secure: Bool = false) {
     
     var inputStream: InputStream
     var outputStream: OutputStream
@@ -79,8 +79,13 @@ public class TCFSocketTransport: TStreamTransport {
     
     if let readStream = readStream?.takeRetainedValue(),
       let writeStream = writeStream?.takeRetainedValue() {
-      CFReadStreamSetProperty(readStream, .shouldCloseNativeSocket, kCFBooleanTrue)
-      CFWriteStreamSetProperty(writeStream, .shouldCloseNativeSocket, kCFBooleanTrue)
+        CFReadStreamSetProperty(readStream, .shouldCloseNativeSocket, kCFBooleanTrue)
+        CFWriteStreamSetProperty(writeStream, .shouldCloseNativeSocket, kCFBooleanTrue)
+      
+        if secure {
+            CFReadStreamSetProperty(readStream, .socketSecurityLevel, StreamSocketSecurityLevel.negotiatedSSL._rawValue)
+            CFWriteStreamSetProperty(writeStream, .socketSecurityLevel, StreamSocketSecurityLevel.negotiatedSSL._rawValue)
+        }
 
       inputStream = readStream as InputStream
       inputStream.schedule(in: .current, forMode: .defaultRunLoopMode)


### PR DESCRIPTION
As TSSLSocketTransport has problems with TLSv1.2 sockets and on iOS 10.3, with this implementation it's possible to use them by simply setting secure = true. Tested on actual server with latest TLSv1.2 and iOS 10.3