### PR TITLE
Swift - Return on early exception handling in flush

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -2173,6 +2173,7 @@ void t_swift_generator::generate_swift_service_client_async_implementation(ostre
     out << indent() << "if let error = error";
     block_open(out);
     out << indent() << error_completion_call << endl;
+    out << indent() << "return" << endl;
     block_close(out);
 
     if (!is_oneway) {


### PR DESCRIPTION
Client: lib/swift

The networking over a url session task may raise an exception before receiving from the protocol, which will always raise a second exception due to the unreadable response.
This change will prevent the dispatching of two different completion callbacks with two different exceptions, the networking exception being the root cause and the second exception not adding any value.
