### PR TITLE
[SWIFT] Close open bracket

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -1475,9 +1475,8 @@ void t_swift_generator::generate_swift_struct_printable_extension(ostream& out, 
       }
       out << "\"" << endl;
     }
-    indent(out) << "desc += \")\"" << endl;
   }
-
+  indent(out) << "desc += \")\"" << endl;
   indent(out) << "return desc" << endl;
   block_close(out);
   out << endl;


### PR DESCRIPTION
This is to close off the open bracket, which will mutate the string and silence the warning recommending the variable to be a constant.