### PR TITLE
[Swift] Conform to new Hashable function

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -886,6 +886,29 @@ void t_swift_generator::generate_swift_struct_hashable_extension(ostream& out,
 
   block_close(out);
   out << endl;
+  
+  indent(out) << visibility << " func hash(into hasher: inout Hasher)";
+  block_open(out);
+  
+  if (!members.empty()) {
+    if (!tstruct->is_union()) {
+      for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
+        t_field* tfield = *m_iter;
+        indent(out) << "hasher.combine(" << maybe_escape_identifier(tfield->get_name()) << ")" << endl;
+      }
+    } else {
+      indent(out) << "switch self {" << endl;
+      for (m_iter = members.begin(); m_iter != members.end(); m_iter++) {
+        t_field *tfield = *m_iter;
+        indent(out) << "case ." << tfield->get_name() << "(let val): hasher.combine(val)" << endl;
+      }
+      indent(out) << "}" << endl << endl;
+    }
+  }
+  
+  block_close(out);
+  out << endl;
+  
   block_close(out);
   out << endl;
 }


### PR DESCRIPTION
New Hashable function introduced in Swift4.2 and the previous version was deprecated in Swift5.0